### PR TITLE
Enable editing of logged reminders

### DIFF
--- a/Notify/ContentView.swift
+++ b/Notify/ContentView.swift
@@ -15,6 +15,10 @@ struct CalendarHistoryView: View {
     @State private var selectedDate: Date = Date()
     @State private var showingManualLog = false
     @State private var manualLogText = ""
+    // Editing state
+    @State private var editingEntry: ReminderEntry?
+    @State private var editText: String = ""
+    @State private var showingEditDialog = false
 
     var entriesForSelectedDate: [ReminderEntry] {
         reminderStore.entries.filter {
@@ -51,6 +55,11 @@ struct CalendarHistoryView: View {
                                     .font(.caption)
                                     .foregroundColor(.gray)
                             }
+                            .onTapGesture {
+                                editingEntry = entry
+                                editText = entry.text
+                                showingEditDialog = true
+                            }
                         }
                         .onDelete(perform: deleteEntries)
                     }
@@ -76,10 +85,37 @@ struct CalendarHistoryView: View {
                     }
                 }
             }
-            .alert("Manual Log", isPresented: $showingManualLog, actions: {
-                TextField("What do you want to say?", text: $manualLogText)
-                Button("Save", action: saveManualEntry)
-                Button("Cancel", role: .cancel) {}
+            .sheet(isPresented: $showingManualLog) {
+                NavigationView {
+                    VStack(alignment: .leading) {
+                        TextEditor(text: $manualLogText)
+                            .padding()
+                            .frame(minHeight: 200)
+                        Spacer()
+                    }
+                    .navigationTitle("Manual Log")
+                    .navigationBarItems(
+                        leading: Button("Cancel") {
+                            showingManualLog = false
+                        },
+                        trailing: Button("Save") {
+                            saveManualEntry()
+                            showingManualLog = false
+                        }
+                    )
+                }
+            }
+            .alert("Edit Entry", isPresented: $showingEditDialog, actions: {
+                TextField("Update text", text: $editText)
+                Button("Save") {
+                    if let entry = editingEntry {
+                        reminderStore.updateEntry(id: entry.id, newText: editText)
+                    }
+                    editingEntry = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    editingEntry = nil
+                }
             })
         }
     }

--- a/Notify/ReminderStore.swift
+++ b/Notify/ReminderStore.swift
@@ -14,8 +14,8 @@ import UserNotifications
 // This struct defines what a single reminder entry looks like.
 struct ReminderEntry: Identifiable, Codable {
     var id = UUID()
-    let date: Date
-    let text: String
+    var date: Date
+    var text: String
     let notificationID: String
 }
 
@@ -51,6 +51,19 @@ class ReminderStore: ObservableObject {
             entries.remove(at: index)
             save()
         }
+    }
+
+    /// Updates the text and optionally the date for a given entry identifier.
+    func updateEntry(id: UUID, newText: String, newDate: Date? = nil) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        entries[index].text = newText
+        if let date = newDate {
+            entries[index].date = date
+        }
+        save()
     }
 
     private func save() {

--- a/NotifyTests/NotifyTests.swift
+++ b/NotifyTests/NotifyTests.swift
@@ -10,7 +10,20 @@ import Testing
 struct NotifyTests {
 
     @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        let store = ReminderStore()
+        // Clear any persisted entries to ensure a clean slate
+        store.entries.removeAll()
+
+        // Add a sample entry
+        let id = UUID()
+        let entry = ReminderEntry(id: id, date: Date(), text: "Initial", notificationID: "test")
+        store.entries.append(entry)
+
+        // Update the entry
+        store.updateEntry(id: id, newText: "Updated")
+
+        // Verify the update
+        #expect(store.entries.first?.text == "Updated")
     }
 
 }


### PR DESCRIPTION
## Summary
- make reminder entry fields mutable so they can be edited
- add `updateEntry` helper that updates an entry and persists changes
- expose UI for editing previous entries in `CalendarHistoryView`
- present a larger sheet for manual logging
- add a simple test covering the update behavior

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686973435b608325833bace976efe233