### PR TITLE
Implement automatic logging and clearing of delivered notifications

### DIFF
--- a/Notify/AppDelegate.swift
+++ b/Notify/AppDelegate.swift
@@ -23,6 +23,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         return true
     }
 
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        guard let store = notificationDelegate?.reminderStore else { return }
+        NotificationManager.shared.logDeliveredNotifications(to: store)
+    }
+
     func setReminderStore(_ store: ReminderStore) {
         let delegate = NotificationDelegate(reminderStore: store)
         notificationDelegate = delegate

--- a/Notify/NotificationManager.swift
+++ b/Notify/NotificationManager.swift
@@ -118,4 +118,26 @@ extension NotificationManager {
             print("❌ Failed to schedule app refresh: \(error)")
         }
     }
+
+    /// Logs any delivered notifications to the provided store and removes them
+    /// from Notification Center. Only logs when the "logDefaultDelivery" setting
+    /// is enabled.
+    func logDeliveredNotifications(to store: ReminderStore) {
+        let center = UNUserNotificationCenter.current()
+        center.getDeliveredNotifications { notifications in
+            let shouldLog = UserDefaults.standard.bool(forKey: "logDefaultDelivery")
+
+            if shouldLog {
+                DispatchQueue.main.async {
+                    for note in notifications {
+                        store.addEntry(text: "Reminder delivered",
+                                       date: note.date,
+                                       notificationID: note.request.identifier)
+                    }
+                }
+            }
+
+            center.removeAllDeliveredNotifications()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a method in `NotificationManager` to log delivered notifications and clear them from Notification Center
- call this new method from `applicationDidBecomeActive` in `AppDelegate`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686abdb85f2083259693b5705b0e0f87